### PR TITLE
Significant performance enhancements to EMAValidator error and notification processing

### DIFF
--- a/emavalidator/src/emavalidator/AbstractErrorEntry.java
+++ b/emavalidator/src/emavalidator/AbstractErrorEntry.java
@@ -363,6 +363,22 @@ public abstract class AbstractErrorEntry
     }
 
     /**
+     * If you override equals() you have to override hashCode() with the same variables used for comparing.
+     * @return The computed hash code that should match in ALL cases where a.equals(b)
+     */
+    @Override
+    public int hashCode() {
+        // don't forget to download the lib for this and fix the project setup:
+        // http://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/builder/HashCodeBuilder.html
+        return new org.apache.commons.lang3.builder.HashCodeBuilder(17, 37).
+                append(this.getErrorColumnNumber()).
+                append(this.errorLevel).
+                append(this.expectedValue).
+                append(this.errorMessage).
+                toHashCode();
+    }
+
+    /**
      * @return The level of severity of this ErrorEntry. Refer to ErrorEntry.ErrorLevel for full documentation.
      */
     public ErrorLevel getErrorLevel() { return this.errorLevel; }

--- a/emavalidator/src/emavalidator/AbstractErrorEntry.java
+++ b/emavalidator/src/emavalidator/AbstractErrorEntry.java
@@ -326,7 +326,6 @@ public abstract class AbstractErrorEntry
      * @return True if philosophically two error values represent the same kind of input mistake made by the operator. False otherwise.
      */
     @Override
-    //TODO(canavan) This is slow when the list of errors is very large. O(n^2) or close to it unfortunately. Unique error IDs would be awesome or a hash table.
     public boolean equals(Object obj)
     {
         if (!(obj instanceof AbstractErrorEntry)) // null check not necessary, instanceof returns false if obj == null

--- a/emavalidator/src/emavalidator/AbstractNotificationEntry.java
+++ b/emavalidator/src/emavalidator/AbstractNotificationEntry.java
@@ -169,7 +169,7 @@ public abstract class AbstractNotificationEntry
 
     /**
      * Compares notification column number, details, and message. If all 3 are the same, then two notifications are considered identical. This is used to aggregate similar notifications.
-     * @return True if philosophically two notoficatoin values represent the same kind of input mistake made by the operator. False otherwise.
+     * @return True if philosophically two notification values represent the same kind of input mistake made by the operator. False otherwise.
      */
     @Override
     public boolean equals(Object obj)
@@ -204,6 +204,20 @@ public abstract class AbstractNotificationEntry
             return false;
 
         return true;
+    }
+
+    /**
+     * @return The computed hash code that hsould match in ALL cases where a.equals(b)
+     */
+    @Override
+    public int hashCode() {
+        // don't forget to download the lib for this and fix the project setup:
+        // http://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/builder/HashCodeBuilder.html
+        return new org.apache.commons.lang3.builder.HashCodeBuilder(17, 37).
+                append(this.getNotificationColumnNumber()).
+                append(this.notificationDetails).
+                append(this.notificationMessage).
+                toHashCode();
     }
 
     /**

--- a/emavalidator/src/emavalidator/AbstractNotificationEntry.java
+++ b/emavalidator/src/emavalidator/AbstractNotificationEntry.java
@@ -168,11 +168,10 @@ public abstract class AbstractNotificationEntry
     }
 
     /**
-     * Compares error levels, error message, expected value, and column number. If all 4 are the same, then two errors are considered identical. This is used to aggregate similar errors. This does NOT take VALUE into account.
-     * @return True if philosophically two error values represent the same kind of input mistake made by the operator. False otherwise.
+     * Compares notification column number, details, and message. If all 3 are the same, then two notifications are considered identical. This is used to aggregate similar notifications.
+     * @return True if philosophically two notoficatoin values represent the same kind of input mistake made by the operator. False otherwise.
      */
     @Override
-    //TODO(canavan) This is slow when the list of errors is very large. O(n^2) or close to it unfortunately. Unique error IDs would be awesome or a hash table.
     public boolean equals(Object obj)
     {
         if (!(obj instanceof AbstractNotificationEntry)) // null check not necessary, instanceof returns false if obj == null


### PR DESCRIPTION
Switch SheetErrorSummary.java to use HashMap\<AbstractError\> and HashMap\<AbstractNotification\> from ArrayList. This changes the error calculation performance complexity from O(N^2) to O(1). This should measurably increase performance for all spreadsheets and significantly so for very large sheets. Large sheets with lots of errors should process 100x+ faster.

Code needs to be built and tested natively before being pushed to production. 